### PR TITLE
Update Python version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "A package to retrieve version controlled software projects from GitHub and GitLab, for further analysis."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License"


### PR DESCRIPTION
Python at version 3.8 causes test failures in pytest. Here, the spec has been bumped to 3.9 in the `pyproject.toml` file. However, this still causes test skips (which could be fixed by #6)