### PR TITLE
Artefact URLs

### DIFF
--- a/robota_core/repository.py
+++ b/robota_core/repository.py
@@ -52,11 +52,6 @@ class Branch:
         self.name = branch["name"]
         self.id = branch["commit_id"]
 
-        if "url" in branch:
-            self.url = branch["url"]
-        else:
-            self.url = None
-
     def _branch_from_github(self, branch: github.Branch.Branch):
         self.name = branch.name
         self.id = branch.commit.sha

--- a/robota_core/repository.py
+++ b/robota_core/repository.py
@@ -46,7 +46,7 @@ class Branch:
         self.id = branch.attributes["commit"]["id"]
 
         if project_url is not None:
-            self.url = f"{project_url}/tree/~/{branch.attributes['name']}"
+            self.url = f"{project_url}/-/tree/{branch.attributes['name']}"
         else:
             self.url = None
 

--- a/robota_core/tests/test_artefact_urls.py
+++ b/robota_core/tests/test_artefact_urls.py
@@ -1,0 +1,16 @@
+import pytest
+from robota_core.repository import GitlabRepository, GithubRepository
+
+class TestGithubUrls:
+    repo = "https://github.com/robota-suite/robota-core"
+    project = "robota-suite/robota-core"
+
+    def test_branch_url(self):
+        server = GithubRepository({
+            "url": self.repo,
+            "project": self.project
+        })
+
+        develop_branch = server.get_branch('develop')
+
+        assert develop_branch.url == "https://github.com/robota-suite/robota-core/tree/develop"


### PR DESCRIPTION
Fixes robota-suite/robota-core#2

Adds a `url` field to the following artefacts:
- `Branch`
- `Diff`
