### PR TITLE
Rename github tools method

### DIFF
--- a/robota_core/github_tools.py
+++ b/robota_core/github_tools.py
@@ -14,10 +14,10 @@ class GithubServer:
         :param setup: dictionary containing GitHub url and authentication token.
         """
         self.url = setup["url"]
-        self.server = self._open_gitlab_connection(setup)
+        self.server: github.Github = self._open_github_connection(setup)
 
     @staticmethod
-    def _open_gitlab_connection(setup: dict):
+    def _open_github_connection(setup: dict) -> github.Github:
         """Open a connection to the GitLab server using authentication token."""
         token = None
         if "token" in setup:


### PR DESCRIPTION
Fixes a mislabeling in GithubServer class method that referenced 'gitlab' instead of 'github'. Additionally, adds type annotations to the method to ensure type safety and maintain consistency of the codebase.

Ref #24