### PR TITLE
Remove Unknown Mark Warning in Pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,16 @@
+[pytest]
+# Define the markers
+markers =
+    config_path: mark a test as using a specific config_path test.
+
+# Set the default command line options
+addopts = --strict-markers
+
+# Set default test path
+testpaths = robota_core
+
+# Set the minimum logging level
+log_cli_level = INFO
+
+# Configure the output format
+console_output_style = progress

--- a/robota_core/github_tools.py
+++ b/robota_core/github_tools.py
@@ -14,10 +14,10 @@ class GithubServer:
         :param setup: dictionary containing GitHub url and authentication token.
         """
         self.url = setup["url"]
-        self.server = self._open_gitlab_connection(setup)
+        self.server: github.Github = self._open_github_connection(setup)
 
     @staticmethod
-    def _open_gitlab_connection(setup: dict):
+    def _open_github_connection(setup: dict) -> github.Github:
         """Open a connection to the GitLab server using authentication token."""
         token = None
         if "token" in setup:

--- a/robota_core/github_tools.py
+++ b/robota_core/github_tools.py
@@ -14,10 +14,10 @@ class GithubServer:
         :param setup: dictionary containing GitHub url and authentication token.
         """
         self.url = setup["url"]
-        self.server: github.Github = self._open_github_connection(setup)
+        self.server = self._open_gitlab_connection(setup)
 
     @staticmethod
-    def _open_github_connection(setup: dict) -> github.Github:
+    def _open_gitlab_connection(setup: dict):
         """Open a connection to the GitLab server using authentication token."""
         token = None
         if "token" in setup:


### PR DESCRIPTION
Adds `pytest.ini` file to define custom markers used in the test files. Additionally, enables --strict-markers option to enforce marker validation. Tests will fail if a marker used in a test is not defined in `pytest.ini`, preventing the unknown mark warning that pytest throws.

Ref #23 