### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,0 +1,1 @@
+* @suzanneEmbury


### PR DESCRIPTION
This is to complement the branch protection recently added to the `develop` and `master` branches.  It is an experiment that will be undone if it proves to annoying to people trying to contribute.